### PR TITLE
bugfix: getFile() breaks when directory has spaces in it

### DIFF
--- a/src/main/java/edu/neu/coe/info6205/util/SortBenchmarkHelper.java
+++ b/src/main/java/edu/neu/coe/info6205/util/SortBenchmarkHelper.java
@@ -80,7 +80,13 @@ public class SortBenchmarkHelper {
     // TEST
     private static String getFile(String resource, @SuppressWarnings("SameParameterValue") Class<?> clazz) throws FileNotFoundException {
         final URL url = clazz.getClassLoader().getResource(resource);
-        if (url != null) return url.getFile();
+        if (url != null) {
+            try {
+                return Paths.get(url.toURI()).toString();
+            } catch (URISyntaxException e) {
+                throw new RuntimeException(e);
+            }
+        }
         throw new FileNotFoundException(resource + " in " + clazz);
     }
 


### PR DESCRIPTION
Greetings professor,

When working on assignment 6, I noticed that getFile() function throws FileNotFoundException when the path to the file contains a space. I've used an alternative method to get the file path using Paths library which works in this case. Tested on windows with the repo stored in a folder with a space in the folder name.